### PR TITLE
Add more STMOD+ PINs description and review power-up sequence

### DIFF
--- a/STModCellular.cpp
+++ b/STModCellular.cpp
@@ -18,7 +18,6 @@
 #include "STModCellular.h"
 #include "mbed_wait_api.h"
 #include "mbed_trace.h"
-#include "DigitalIn.h"
 
 #define TRACE_GROUP "CELL"
 
@@ -29,15 +28,12 @@ STModCellular::STModCellular(FileHandle *fh) : STMOD_CELLULAR_MODEM(fh),
     m_reset(MBED_CONF_STMOD_CELLULAR_RESET),
     m_simsel0(MBED_CONF_STMOD_CELLULAR_SIMSEL0),
     m_simsel1(MBED_CONF_STMOD_CELLULAR_SIMSEL1),
-    m_mdmdtr(MBED_CONF_STMOD_CELLULAR_MDMDTR)
+    m_mdmdtr(MBED_CONF_STMOD_CELLULAR_MDMDTR),
+    m_sim_reset(MBED_CONF_STMOD_CELLULAR_SIM_RESET),
+    m_sim_clk(MBED_CONF_STMOD_CELLULAR_SIM_CLK),
+    m_sim_data(MBED_CONF_STMOD_CELLULAR_SIM_DATA)
 {
-
     tr_debug("STModCellular creation\r\n");
-
-    /* Ensure PIN SIMs are set as input */
-    DigitalIn sim_reset(MBED_CONF_STMOD_CELLULAR_SIM_RESET);
-    DigitalIn sim_clk(MBED_CONF_STMOD_CELLULAR_SIM_CLK);
-    DigitalIn sim_data(MBED_CONF_STMOD_CELLULAR_SIM_DATA);
 
     // start with modem disabled
     m_powerkey.write(0);

--- a/STModCellular.cpp
+++ b/STModCellular.cpp
@@ -121,6 +121,7 @@ nsapi_error_t STModCellular::soft_power_on() {
         _at->write_int(2);
         _at->cmd_stop_read_resp();
         err = _at->get_last_error();
+        _at->restore_at_timeout();
         _at->unlock();
 
         if (err == NSAPI_ERROR_OK) {

--- a/STModCellular.cpp
+++ b/STModCellular.cpp
@@ -133,11 +133,13 @@ nsapi_error_t STModCellular::soft_power_on() {
 
     wait_ms(500);
 
+#if MBED_CONF_CELLULAR_DEBUG_AT
     _at->lock();
     /*  Verify Flow Control settings */
     _at->cmd_start("AT+IFC?");
     _at->cmd_stop_read_resp();
     _at->unlock();
+#endif // MBED_CONF_CELLULAR_DEBUG_AT
 
     return err;
 }

--- a/STModCellular.h
+++ b/STModCellular.h
@@ -19,11 +19,25 @@
 #define STMOD_CELLULAR_H_
 
 #include "QUECTEL_UG96.h"
+#include "QUECTEL_BG96.h"
 #include "DigitalOut.h"
+
+/* List of supported STMOD+ cellular expansion boards */
+#define STMOD_BG96 0
+#define STMOD_UG96 1
+
+
+#if (MBED_CONF_STMOD_CELLULAR_TYPE == STMOD_BG96)
+#define STMOD_CELLULAR_MODEM QUECTEL_BG96
+#endif
+
+#if (MBED_CONF_STMOD_CELLULAR_TYPE == STMOD_UG96)
+#define STMOD_CELLULAR_MODEM QUECTEL_UG96
+#endif
 
 namespace mbed {
 
-class STModCellular : public QUECTEL_UG96 {
+class STModCellular : public STMOD_CELLULAR_MODEM {
 private:
     DigitalOut m_powerkey;
     DigitalOut m_reset;

--- a/STModCellular.h
+++ b/STModCellular.h
@@ -21,6 +21,7 @@
 #include "QUECTEL_UG96.h"
 #include "QUECTEL_BG96.h"
 #include "DigitalOut.h"
+#include "DigitalIn.h"
 
 /* List of supported STMOD+ cellular expansion boards */
 #define STMOD_BG96 0
@@ -44,6 +45,9 @@ private:
     DigitalOut m_simsel0;
     DigitalOut m_simsel1;
     DigitalOut m_mdmdtr;
+    DigitalIn m_sim_reset;
+    DigitalIn m_sim_clk;
+    DigitalIn m_sim_data;
 public:
     STModCellular(FileHandle *fh);
     virtual nsapi_error_t soft_power_on();

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -5,57 +5,57 @@
             "help": "STMOD+ connected modem can be either STMOD_UG96 or STMOD_BG96",
             "value": "STMOD_BG96"
         },
-        "mdmdtr": {
-            "help": "Modem's Data Terminal Ready",
-            "value": "NC"
-        },
-        "simsel0": {
-            "help": "Module sim select pin 0.",
-            "value": "NC"
-        },
         "sim_selection": {
             "help": "Module sim selection. 0 for plastic sim, 1 for esim.",
             "value": 0
         },
-        "simsel1": {
-            "help": "Module sim select pin 1.",
+        "mdmdtr": {
+            "help": "Modem's Data Terminal Ready. Usually not connected to STMOD+ connector. It needs to be set/overwritten otherwise",
             "value": "NC"
+        },
+        "simsel0": {
+            "help": "Module sim select pin 0. By default connected to STMOD+ pin 18. It needs to be set/overwritten otherwise",
+            "value": "STMOD_18"
+        },
+        "simsel1": {
+            "help": "Module sim select pin 1. By default connected to STMOD+ pin 8. It needs to be set/overwritten otherwise",
+            "value": "STMOD_8"
         },
         "sim_reset": {
-            "help": "Module sim reset pin. Used for sim selection sequence.",
-            "value": "NC"
+            "help": "Module sim reset pin. Used for sim selection sequence. By default connected to STMOD+ pin 17. It needs to be set/overwritten otherwise",
+            "value": "STMOD_17"
         },
         "sim_clk": {
-            "help": "Module sim clock pin. Used for sim selection sequence..",
-            "value": "NC"
+            "help": "Module sim clock pin. Used for sim selection sequence. By default connected to STMOD+ pin 13. It needs to be set/overwritten otherwise",
+            "value": "STMOD_13"
         },
         "sim_data": {
-            "help": "Module sim data pin. Used for sim selection sequence.",
-            "value": "NC"
+            "help": "Module sim data pin. Used for sim selection sequence. By default connected to STMOD+ pin 19. It needs to be set/overwritten otherwise",
+            "value": "STMOD_19"
          },
          "power": {
-            "help": "Modem's power key.",
-            "value": "NC"
+            "help": "Modem's power key. By default connected to STMOD+ pin 9. It needs to be set/overwritten otherwise",
+            "value": "STMOD_9"
         },
         "reset": {
-            "help": "Modem's reset.",
-            "value": "NC"
+            "help": "Modem's reset. By default connected to STMOD+ pin 12. It needs to be set/overwritten otherwise",
+            "value": "STMOD_12"
         },
         "tx": {
-            "help": "TX pin for serial connection. D1 assumed if Arduino Form Factor, needs to be set/overwritten otherwise.",
-            "value": null
+            "help": "TX pin for serial connection. STMOD pin 2 is the default STMOD+ UART TX. It needs to be set/overwritten otherwise",
+            "value": "STMOD_2"
         },
         "rx": {
-            "help": "RX pin for serial connection. D0 assumed if Arduino Form Factor, needs to be set/overwritten otherwise.",
-            "value": null
+            "help": "RX pin for serial connection. STMOD pin 3 is the default STMOD+ UART TX. It needs to be set/overwritten otherwise.",
+            "value": "STMOD_3"
         },
         "rts": {
-            "help": "RTS pin for serial connection",
-            "value": "NC"
+            "help": "RTS pin for serial connection. STMOD pin 4 is the default STMOD+ UART RTS. It needs to be set/overwritten otherwise.",
+            "value": "STMOD_4"
         },
         "cts": {
-            "help": "CTS pin for serial connection",
-            "value": "NC"
+            "help": "CTS pin for serial connection. STMOD pin 1 is the default STMOD+ UART RTS. It needs to be set/overwritten otherwise.",
+            "value": "STMOD_1"
         },
         "baudrate" : {
             "help": "Serial connection baud rate",
@@ -64,23 +64,6 @@
         "provide-default": {
             "help": "Provide as default CellularDevice [true/false]",
             "value": false
-        }
-    },
-    "target_overrides": {
-        "DISCO_L496AG": {
-            "tx": "PB_6",
-            "rx": "PG_10",
-            "rts": "PG_12",
-            "cts": "PG_11",
-            "mdmdtr": "NC",
-            "power": "PD_3",
-            "sim_reset": "PC_7",
-            "sim_clk": "PA_4",
-            "sim_data": "PB_12",
-            "simsel0": "PC_2",
-            "simsel1": "PI_3",
-            "sim_selection": 0,
-            "reset": "PB_2"
         }
     }
 }

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -1,6 +1,10 @@
 {
     "name": "stmod_cellular",
     "config": {
+        "type": {
+            "help": "STMOD+ connected modem can be either STMOD_UG96 or STMOD_BG96",
+            "value": "STMOD_BG96"
+        },
         "mdmdtr": {
             "help": "Modem's Data Terminal Ready",
             "value": "NC"
@@ -17,7 +21,19 @@
             "help": "Module sim select pin 1.",
             "value": "NC"
         },
-        "power": {
+        "sim_reset": {
+            "help": "Module sim reset pin. Used for sim selection sequence.",
+            "value": "NC"
+        },
+        "sim_clk": {
+            "help": "Module sim clock pin. Used for sim selection sequence..",
+            "value": "NC"
+        },
+        "sim_data": {
+            "help": "Module sim data pin. Used for sim selection sequence.",
+            "value": "NC"
+         },
+         "power": {
             "help": "Modem's power key.",
             "value": "NC"
         },
@@ -54,10 +70,13 @@
         "DISCO_L496AG": {
             "tx": "PB_6",
             "rx": "PG_10",
-            "rts": "NC",
-            "cts": "NC",
-            "mdmdtr": "PA_0",
+            "rts": "PG_12",
+            "cts": "PG_11",
+            "mdmdtr": "NC",
             "power": "PD_3",
+            "sim_reset": "PC_7",
+            "sim_clk": "PA_4",
+            "sim_data": "PB_12",
             "simsel0": "PC_2",
             "simsel1": "PI_3",
             "sim_selection": 0,


### PR DESCRIPTION
Also add STMOD+ cellular type to select either BG96 or UG96.
BG96 supported by default.

Tested OK with mbed-os-example-cellular with both PPP mode true and false.